### PR TITLE
FrameWork.MadeByMe.BusinessRules.Updated-01.07.2025-Main

### DIFF
--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/BusinessRulesSettings/RulePathSObjectSettingUpsertService.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/BusinessRulesSettings/RulePathSObjectSettingUpsertService.cls
@@ -7,39 +7,56 @@ public with sharing class RulePathSObjectSettingUpsertService {
     private RulePathSObjectSettingRepository repository;
     private BusinessRulesSettingValidator validator;
 
+    private BR_RulePathFieldSettingRepository rulePathFieldSettingRepositoryInstance;
+
     public RulePathSObjectSettingUpsertService(){
         this.repository = RulePathSObjectSettingRepository.getInstance();
         this.validator = BusinessRulesSettingValidator.getInstance();
+
+        this.rulePathFieldSettingRepositoryInstance = BR_RulePathFieldSettingRepository.getInstance();
     }
 
     private static final String RULE_KEY_DELIMITER = ';';
+    private static final String FIELD_SETTING_COMPOSITE_SEPARATOR = '-';
     
-    public List<RulePathSObjectSetting__c> byBusinessRulesSettingsRuleKey( List<BusinessRulesSetting__c> newBusinessRulesSettings, Map<Id,BusinessRulesSetting__c> oldBusinessRulesSettingById ) {
+    public Map<String,List<SObject>> byBusinessRulesSettingsRuleKey( List<BusinessRulesSetting__c> newBusinessRulesSettings, Map<Id,BusinessRulesSetting__c> oldBusinessRulesSettingById ) {
 
         List<String> objectNames = Lists.byField( newBusinessRulesSettings, 'Object__c' );
 
         Map<String, RulePathSObjectSetting__c> rulePathSObjectSettingByObjectName = (Map<String, RulePathSObjectSetting__c>) Maps.indexBy(
-            'Name'
-            , this.repository.findByNames( objectNames )
+            'ObjectAPIName__c'
+            , this.repository.findByObjectAPINames( objectNames )
             , Map<String, RulePathSObjectSetting__c>.class
+        );
+
+        Map<String,RulePathFieldSetting__c> rulePathFieldSettingByObjectNameAndFieldName = (Map<String,RulePathFieldSetting__c>) Maps.indexByCompositeKey(
+            new List<String>{ 'Name', 'ObjectAPIName__c' }
+            , this.rulePathFieldSettingRepositoryInstance.findByObjectNames( objectNames )
+            , FIELD_SETTING_COMPOSITE_SEPARATOR
+            , Map<String,RulePathFieldSetting__c>.class
         );
 
         Map<String,Schema.DescribeSobjectResult> describeSObjectByName = SObjectHelper.getDescribreSObjectByName( objectNames );
 
-        return this.repository.save(
-            this.getBusinessRulesSettingsToUpsert(
-                newBusinessRulesSettings
-                , oldBusinessRulesSettingById
-                , rulePathSObjectSettingByObjectName
-                , describeSObjectByName
-            )
+        Map<String,List<SObject>> result = this.getSObjectSettingsAndFieldSettingsToUpsert(
+            newBusinessRulesSettings
+            , oldBusinessRulesSettingById
+            , rulePathSObjectSettingByObjectName
+            , rulePathFieldSettingByObjectNameAndFieldName
+            , describeSObjectByName
         );
+
+        this.repository.save( result.get( 'RulePathSObjectSetting__c' ) );
+        this.rulePathFieldSettingRepositoryInstance.save( result.get( 'RulePathFieldSetting__c' ) );
+
+        return result;
     }
 
-    private List<RulePathSObjectSetting__c> getBusinessRulesSettingsToUpsert(
+    private Map<String,List<SObject>> getSObjectSettingsAndFieldSettingsToUpsert(
         List<BusinessRulesSetting__c> newBusinessRulesSettings
         , Map<Id,BusinessRulesSetting__c> oldBusinessRulesSettingById
         , Map<String, RulePathSObjectSetting__c> rulePathSObjectSettingByObjectName
+        , Map<String,RulePathFieldSetting__c> rulePathFieldSettingByObjectNameAndFieldName
         , Map<String,Schema.DescribeSobjectResult> describeSObjectByName
     ) {
         for( BusinessRulesSetting__c newBusinessRulesSetting : newBusinessRulesSettings ) {
@@ -48,19 +65,24 @@ public with sharing class RulePathSObjectSettingUpsertService {
             String ruleKeyDifference = this.getRuleKeyFieldsDifference( newBusinessRulesSetting, oldBusinessRulesSettingById );
             if( String.isBlank( ruleKeyDifference ) ) continue;
 
-            RulePathSObjectSetting__c rulePathSObjectSetting = this.getOrCreateRulePathSetting( rulePathSObjectSettingByObjectName, newBusinessRulesSetting );
-
             List<String> fieldsToAddInQuery = this.extractFieldsFromRuleKeyDifference( ruleKeyDifference );
 
             this.validator.ruleKeyFieldsIsValid( fieldsToAddInQuery, describeSObjectByName, newBusinessRulesSetting );
             if( newBusinessRulesSetting.hasErrors() ) continue;
 
-            rulePathSObjectSetting.FieldsToUseInQuery__c = this.mergeQueryFields( rulePathSObjectSetting.FieldsToUseInQuery__c, fieldsToAddInQuery );
+            RulePathSObjectSetting__c rulePathSObjectSetting = this.getOrCreateRulePathSetting( rulePathSObjectSettingByObjectName, newBusinessRulesSetting );
 
-            rulePathSObjectSettingByObjectName.put( rulePathSObjectSetting.Name, rulePathSObjectSetting );
+            rulePathFieldSettingByObjectNameAndFieldName = this.mergeQueryFields( rulePathFieldSettingByObjectNameAndFieldName, fieldsToAddInQuery, rulePathSObjectSetting.ObjectAPIName__c );
+
+            if( String.isBlank( rulePathSObjectSetting.Id ) ) {
+                rulePathSObjectSettingByObjectName.put( rulePathSObjectSetting.ObjectAPIName__c, rulePathSObjectSetting );
+            }
         }
 
-        return rulePathSObjectSettingByObjectName.values();
+        return new Map<String,List<SObject>>{
+            'RulePathSObjectSetting__c' => rulePathSObjectSettingByObjectName.values()
+            , 'RulePathFieldSetting__c' => rulePathFieldSettingByObjectNameAndFieldName.values()
+        };
     }
 
     private String getRuleKeyFieldsDifference( BusinessRulesSetting__c newBusinessRulesSetting, Map<Id,BusinessRulesSetting__c> oldBusinessRulesSettingById ) {
@@ -80,8 +102,7 @@ public with sharing class RulePathSObjectSettingUpsertService {
         }
 
         return new BR_RulePathSObjectSettingBuilder()
-            .withName( newBusinessRulesSetting.Object__c )
-            .withFieldsToUseInQuery( '' )
+            .withObjectAPIName( newBusinessRulesSetting.Object__c )
             .build();
     }
 
@@ -97,16 +118,21 @@ public with sharing class RulePathSObjectSettingUpsertService {
         return fieldsToAddInQuery;
     }
 
-    private String mergeQueryFields( String fieldsToUseInQuery, List<String> fieldsToAddInQuery ) {
+    private Map<String,RulePathFieldSetting__c> mergeQueryFields( Map<String,RulePathFieldSetting__c> rulePathFieldSettingByObjectNameAndFieldName, List<String> fieldsToAddInQuery, String objectApiName ) {
 
-        Set<String> fieldSet = new Set<String>();
+        for( String fieldToAddInQuery : fieldsToAddInQuery ) {
+            if( rulePathFieldSettingByObjectNameAndFieldName.containsKey( fieldToAddInQuery + FIELD_SETTING_COMPOSITE_SEPARATOR + objectApiName ) ) continue;
 
-        if ( !String.isBlank( fieldsToUseInQuery ) ) {
-            fieldSet.addAll( fieldsToUseInQuery.split( ',' ) );
+            rulePathFieldSettingByObjectNameAndFieldName.put(
+                fieldToAddInQuery + FIELD_SETTING_COMPOSITE_SEPARATOR + objectApiName
+                , new BR_RulePathFieldSettingBuilder()
+                    .withName( fieldToAddInQuery )
+                    .withRelatedSObjectAPIName( objectApiName )
+                    .build()
+            );
         }
 
-        fieldSet.addAll( fieldsToAddInQuery );
-        return String.join( new List<String>( fieldSet ), ',' );
+        return rulePathFieldSettingByObjectNameAndFieldName;
 
     }
 

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/BusinessRulesSettings/Tests/BusinessRulesSettingHandlerTest.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/BusinessRulesSettings/Tests/BusinessRulesSettingHandlerTest.cls
@@ -18,12 +18,25 @@ public with sharing class BusinessRulesSettingHandlerTest {
 
         Test.stopTest();
 
-        RulePathSObjectSetting__c rulePathSObjectSetting = [SELECT Id, Name, FieldsToUseInQuery__c FROM RulePathSObjectSetting__c];
+        RulePathSObjectSetting__c rulePathSObjectSetting = [SELECT Id, ObjectAPIName__c FROM RulePathSObjectSetting__c];
 
         Assert.isNotNull( rulePathSObjectSetting, 'Must return one rulePathSObjectSetting' );
-        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSetting.Name, 'Name field must be: BusinessRulesSetting__c' );
-        Assert.isTrue( rulePathSObjectSetting.FieldsToUseInQuery__c.contains( 'Name' ), 'Should contains Name in FieldsToUseInQuery__c field' );
-        Assert.isTrue( rulePathSObjectSetting.FieldsToUseInQuery__c.contains( 'Object__c' ), 'Should contains Object__c in FieldsToUseInQuery__c field' );
+        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSetting.ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
+
+        List<RulePathFieldSetting__c> rulePathFieldSettings = [SELECT Id, Name, RulePathSObjectSetting__c FROM RulePathFieldSetting__c];
+
+        Assert.isFalse( rulePathFieldSettings.isEmpty(), 'Must return rulePathFieldSettings' );
+        Assert.areEqual( 2, rulePathFieldSettings.size(), 'Must return two rulePathFieldSettings' );
+
+        Map<String,RulePathFieldSetting__c> rulePathFieldSettingByName = (Map<String,RulePathFieldSetting__c>) Maps.indexBy(
+            'Name', rulePathFieldSettings, Map<String,RulePathFieldSetting__c>.class
+        );
+
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Name' ), 'Should contains Name in rulePathFieldSettingByName map' );
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Object__c' ), 'Should contains Object__c in rulePathFieldSettingByName map' );
+
+        Assert.areEqual( rulePathSObjectSetting.id, rulePathFieldSettingByName.get( 'Name' ).RulePathSObjectSetting__c, 'RulePathSObjectSetting__c must be: ' + rulePathSObjectSetting.id );
+        Assert.areEqual( rulePathSObjectSetting.id, rulePathFieldSettingByName.get( 'Object__c' ).RulePathSObjectSetting__c, 'RulePathSObjectSetting__c must be: ' + rulePathSObjectSetting.id );
     }
 
     @isTest
@@ -38,7 +51,11 @@ public with sharing class BusinessRulesSettingHandlerTest {
         TriggerHandler.clearBypass( 'BusinessRulesSettingHandler' );
 
         RulePathSObjectSetting__c rulePathSetting = (RulePathSObjectSetting__c) new RulePathSObjectSettingFactory.DefaultRT(
-            'BusinessRulesSetting__c', 'Name'
+            'BusinessRulesSetting__c'
+        ).createRecord();
+
+        RulePathFieldSetting__c rulePathFieldSetting = (RulePathFieldSetting__c) new BR_RulePathFieldSettingFactory.DefaultRT(
+            'Name', rulePathSetting.Id
         ).createRecord();
 
         Test.startTest();
@@ -48,12 +65,25 @@ public with sharing class BusinessRulesSettingHandlerTest {
 
         Test.stopTest();
 
-        RulePathSObjectSetting__c rulePathSObjectSetting = [SELECT Id, Name, FieldsToUseInQuery__c FROM RulePathSObjectSetting__c];
+        RulePathSObjectSetting__c rulePathSObjectSetting = [SELECT Id, ObjectAPIName__c FROM RulePathSObjectSetting__c];
 
         Assert.isNotNull( rulePathSObjectSetting, 'Must return one rulePathSObjectSetting' );
-        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSetting.Name, 'Name field must be: BusinessRulesSetting__c' );
-        Assert.isTrue( rulePathSObjectSetting.FieldsToUseInQuery__c.contains( 'Name' ), 'Should contains Name in FieldsToUseInQuery__c field' );
-        Assert.isTrue( rulePathSObjectSetting.FieldsToUseInQuery__c.contains( 'Object__c' ), 'Should contains Object__c in FieldsToUseInQuery__c field' );
+        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSetting.ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
+
+        List<RulePathFieldSetting__c> rulePathFieldSettings = [SELECT Id, Name, RulePathSObjectSetting__c FROM RulePathFieldSetting__c];
+
+        Assert.isFalse( rulePathFieldSettings.isEmpty(), 'Must return rulePathFieldSettings' );
+        Assert.areEqual( 2, rulePathFieldSettings.size(), 'Must return two rulePathFieldSettings' );
+
+        Map<String,RulePathFieldSetting__c> rulePathFieldSettingByName = (Map<String,RulePathFieldSetting__c>) Maps.indexBy(
+            'Name', rulePathFieldSettings, Map<String,RulePathFieldSetting__c>.class
+        );
+
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Name' ), 'Should contains Name in rulePathFieldSettingByName map' );
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Object__c' ), 'Should contains Object__c in rulePathFieldSettingByName map' );
+
+        Assert.areEqual( rulePathSObjectSetting.id, rulePathFieldSettingByName.get( 'Name' ).RulePathSObjectSetting__c, 'RulePathSObjectSetting__c must be: ' + rulePathSObjectSetting.id );
+        Assert.areEqual( rulePathSObjectSetting.id, rulePathFieldSettingByName.get( 'Object__c' ).RulePathSObjectSetting__c, 'RulePathSObjectSetting__c must be: ' + rulePathSObjectSetting.id );
     }
 
     @isTest 
@@ -75,9 +105,13 @@ public with sharing class BusinessRulesSettingHandlerTest {
 
         Test.stopTest();
 
-        List<RulePathSObjectSetting__c> rulePathSObjectSettings = [SELECT Id, Name, FieldsToUseInQuery__c FROM RulePathSObjectSetting__c];
+        List<RulePathSObjectSetting__c> rulePathSObjectSettings = [SELECT Id, ObjectAPIName__c FROM RulePathSObjectSetting__c];
 
         Assert.isTrue( rulePathSObjectSettings.isEmpty(), 'Must dont return rulePathSObjectSettings' );
+
+        List<RulePathFieldSetting__c> rulePathFieldSettings = [SELECT Id, Name FROM RulePathFieldSetting__c];
+
+        Assert.isTrue( rulePathFieldSettings.isEmpty(), 'Must not return rulePathFieldSettings' );
     }
 
     @isTest
@@ -92,7 +126,11 @@ public with sharing class BusinessRulesSettingHandlerTest {
         TriggerHandler.clearBypass( 'BusinessRulesSettingHandler' );
 
         RulePathSObjectSetting__c rulePathSetting = (RulePathSObjectSetting__c) new RulePathSObjectSettingFactory.DefaultRT(
-            'BusinessRulesSetting__c', 'Name'
+            'BusinessRulesSetting__c'
+        ).createRecord();
+
+        RulePathFieldSetting__c rulePathFieldSetting = (RulePathFieldSetting__c) new BR_RulePathFieldSettingFactory.DefaultRT(
+            'Name', rulePathSetting.Id
         ).createRecord();
 
         Test.startTest();
@@ -108,11 +146,15 @@ public with sharing class BusinessRulesSettingHandlerTest {
 
         Test.stopTest();
 
-        RulePathSObjectSetting__c rulePathSObjectSetting = [SELECT Id, Name, FieldsToUseInQuery__c FROM RulePathSObjectSetting__c];
+        RulePathSObjectSetting__c rulePathSObjectSettingAfterUpdate = [SELECT Id, ObjectAPIName__c FROM RulePathSObjectSetting__c];
 
-        Assert.isNotNull( rulePathSObjectSetting, 'Must return one rulePathSObjectSetting' );
-        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSetting.Name, 'Name field must be: BusinessRulesSetting__c' );
-        Assert.areEqual( 'Name', rulePathSObjectSetting.FieldsToUseInQuery__c, 'FieldsToUseInQuery__c field must be: Name' );
+        Assert.isNotNull( rulePathSObjectSettingAfterUpdate, 'Must return one rulePathSObjectSettingAfterUpdate' );
+        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSettingAfterUpdate.ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
+
+        RulePathFieldSetting__c rulePathFieldSettingAfterUpdate = [SELECT Id, Name, RulePathSObjectSetting__c FROM RulePathFieldSetting__c WHERE Id = :rulePathFieldSetting.Id];
+        Assert.isNotNull( rulePathFieldSettingAfterUpdate, 'Must return one rulePathFieldSetting' );
+        Assert.areEqual( 'Name', rulePathFieldSettingAfterUpdate.Name, 'Name field must be: Name' );
+        Assert.areEqual( rulePathSetting.Id, rulePathFieldSettingAfterUpdate.RulePathSObjectSetting__c, 'RulePathSObjectSetting__c must be the same' );
     }
 
 }

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/BusinessRulesSettings/Tests/RulePathSObjectSettingUpsertServiceTest.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/BusinessRulesSettings/Tests/RulePathSObjectSettingUpsertServiceTest.cls
@@ -7,26 +7,26 @@ private class RulePathSObjectSettingUpsertServiceTest {
 
     @isTest
     private static void dontUpsertEmptyNewBusinessRulesSettings() {
-
         RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( '[]' ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( '[]' ) );
 
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( new List<BusinessRulesSetting__c>(), null );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( new List<BusinessRulesSetting__c>(), null );
 
         Test.stopTest();
 
-        Assert.areEqual( 0, rulePathSObjectSettingsEnriched.size(), 'rulePathSObjectSettingsEnriched must be empty' );
+        Assert.isTrue( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be empty' );
+        Assert.isTrue( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be empty' );
     }
 
     @isTest
     private static void dontUpsertNewBusinessRulesSettingRuleKeyIsBlank() {
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( '[]' ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( '[]' ) );
 
         String businessRulesSettingFakeId = FixtureFactory.generateFakeId18( BusinessRulesSetting__c.getSObjectType() );
-
-        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( '[]' ) );
 
         String businessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":null}]';
 
@@ -35,16 +35,18 @@ private class RulePathSObjectSettingUpsertServiceTest {
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( businessRulesSettings, null );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, null );
 
         Test.stopTest();
 
-        Assert.areEqual( 0, rulePathSObjectSettingsEnriched.size(), 'rulePathSObjectSettingsEnriched must be empty' );
+        Assert.isTrue( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be empty' );
+        Assert.isTrue( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be empty' );
     }
 
     @isTest 
-    private static void createOldBusinessRulesNull() {
+    private static void createInInsertingScenario() {
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( '[]' ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( '[]' ) );
 
         String businessRulesSettingFakeId = FixtureFactory.generateFakeId18( BusinessRulesSetting__c.getSObjectType() );
 
@@ -55,19 +57,32 @@ private class RulePathSObjectSettingUpsertServiceTest {
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( businessRulesSettings, null );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, null );
 
         Test.stopTest();
 
-        Assert.areEqual( 1, rulePathSObjectSettingsEnriched.size(), 'Must return one rulePathSObjectSettingsEnriched' );
-        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSettingsEnriched[0].Name, 'Name field must be: BusinessRulesSetting__c' );
-        Assert.isTrue( rulePathSObjectSettingsEnriched[0].FieldsToUseInQuery__c.contains( 'Name' ), 'Should contains Name in FieldsToUseInQuery__c field' );
-        Assert.isTrue( rulePathSObjectSettingsEnriched[0].FieldsToUseInQuery__c.contains( 'Object__c' ), 'Should contains Object__c in FieldsToUseInQuery__c field' );
+        Assert.isFalse( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be not empty' );
+        Assert.isFalse( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be not empty' );
+
+        Assert.areEqual( 1, result.get( 'RulePathSObjectSetting__c' ).size(), 'Must return one RulePathSObjectSetting__c' );
+        Assert.areEqual( 2, result.get( 'RulePathFieldSetting__c' ).size(), 'Must return two RulePathFieldSetting__c' );
+
+        Assert.areEqual( 'BusinessRulesSetting__c', ( (RulePathSObjectSetting__c) result.get( 'RulePathSObjectSetting__c' )[0] ).ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
+    
+        Map<String,RulePathFieldSetting__c> rulePathFieldSettingByName = (Map<String,RulePathFieldSetting__c>) Maps.indexBy(
+            'Name'
+            , result.get( 'RulePathFieldSetting__c' )
+            , Map<String,RulePathFieldSetting__c>.class
+        );
+
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Name' ), 'Should contains Name in RulePathFieldSetting' );
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Object__c' ), 'Should contains Object__c in RulePathFieldSetting' );
     }
 
     @isTest 
-    private static void createNewBusinessRuleRuleKeyNotNull() {
+    private static void createInUpdateScenarioOldKeyValueBlank() {
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( '[]' ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( '[]' ) );
 
         String businessRulesSettingFakeId = FixtureFactory.generateFakeId18( BusinessRulesSetting__c.getSObjectType() );
 
@@ -80,25 +95,82 @@ private class RulePathSObjectSettingUpsertServiceTest {
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
 
         Test.stopTest();
 
-        Assert.areEqual( 1, rulePathSObjectSettingsEnriched.size(), 'Must return one rulePathSObjectSettingsEnriched' );
-        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSettingsEnriched[0].Name, 'Name field must be: BusinessRulesSetting__c' );
-        Assert.isTrue( rulePathSObjectSettingsEnriched[0].FieldsToUseInQuery__c.contains( 'Name' ), 'Should contains Name in FieldsToUseInQuery__c field' );
-        Assert.isTrue( rulePathSObjectSettingsEnriched[0].FieldsToUseInQuery__c.contains( 'Object__c' ), 'Should contains Object__c in FieldsToUseInQuery__c field' );
+        Assert.isFalse( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be not empty' );
+        Assert.isFalse( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be not empty' );
+
+        Assert.areEqual( 1, result.get( 'RulePathSObjectSetting__c' ).size(), 'Must return one RulePathSObjectSetting__c' );
+        Assert.areEqual( 2, result.get( 'RulePathFieldSetting__c' ).size(), 'Must return two RulePathFieldSetting__c' );
+
+        Assert.areEqual( 'BusinessRulesSetting__c', ( (RulePathSObjectSetting__c) result.get( 'RulePathSObjectSetting__c' )[0] ).ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
+    
+        Map<String,RulePathFieldSetting__c> rulePathFieldSettingByName = (Map<String,RulePathFieldSetting__c>) Maps.indexBy(
+            'Name'
+            , result.get( 'RulePathFieldSetting__c' )
+            , Map<String,RulePathFieldSetting__c>.class
+        );
+
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Name' ), 'Should contains Name in RulePathFieldSetting' );
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Object__c' ), 'Should contains Object__c in RulePathFieldSetting' );
+    }
+
+    @isTest 
+    private static void createInInsertingTwoScenario() {
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( '[]' ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( '[]' ) );
+
+        List<String> businessRulesSettingFakeIds = FixtureFactory.generateFakeIds18( BusinessRulesSetting__c.getSObjectType(), 2 );
+
+        String businessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeIds[0]+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName;Object__c=Account"},{"Id":"'+businessRulesSettingFakeIds[1]+'","Object__c":"Account","RuleKey__c":"Id=TestId"}]';
+
+        List<BusinessRulesSetting__c> businessRulesSettings = BusinessRulesSettingFactory.fromJsonArray( businessRulesSettingsPayload );
+
+        Test.startTest();
+
+        RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, null );
+
+        Test.stopTest();
+
+        Assert.isFalse( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be not empty' );
+        Assert.isFalse( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be not empty' );
+
+        Assert.areEqual( 2, result.get( 'RulePathSObjectSetting__c' ).size(), 'Must return two RulePathSObjectSetting__c' );
+        Assert.areEqual( 3, result.get( 'RulePathFieldSetting__c' ).size(), 'Must return three RulePathFieldSetting__c' );
+
+        Map<String,RulePathSObjectSetting__c> rulePathSObjectSettingByName = (Map<String,RulePathSObjectSetting__c>) Maps.indexBy(
+            'ObjectAPIName__c'
+            , result.get( 'RulePathSObjectSetting__c' )
+            , Map<String,RulePathSObjectSetting__c>.class
+        );
+
+        Assert.isTrue( rulePathSObjectSettingByName.containsKey( 'BusinessRulesSetting__c' ), 'Should contains BusinessRulesSetting__c in RulePathSObjectSetting' );
+        Assert.isTrue( rulePathSObjectSettingByName.containsKey( 'Account' ), 'Should contains Account in RulePathSObjectSetting' );
+
+        Map<String,RulePathFieldSetting__c> rulePathFieldSettingByName = (Map<String,RulePathFieldSetting__c>) Maps.indexBy(
+            'Name'
+            , result.get( 'RulePathFieldSetting__c' )
+            , Map<String,RulePathFieldSetting__c>.class
+        );
+
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Name' ), 'Should contains Name in RulePathFieldSetting' );
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Object__c' ), 'Should contains Object__c in RulePathFieldSetting' );
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Id' ), 'Should contains Id in RulePathFieldSetting' );
     }
 
     @isTest 
     private static void dontUpdateBusinessRuleRuleKeyDontChanged() {
+        String rulePathSObjectSettingFakeId = FixtureFactory.generateFakeId18( RulePathSObjectSetting__c.getSObjectType() );
+
+        String rulePathSObjectSettingsPayload = '[{"Id":"'+rulePathSObjectSettingFakeId+'","ObjectAPIName__c":"BusinessRulesSetting__c"}]';
+
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( rulePathSObjectSettingsPayload ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( '[]' ) );
 
         String businessRulesSettingFakeId = FixtureFactory.generateFakeId18( BusinessRulesSetting__c.getSObjectType() );
-
-        String rulepathSObjectSettingsPayload = '[{"Name":"BusinessRulesSetting__c"}]';
-
-        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( rulepathSObjectSettingsPayload ) );
 
         String oldBusinessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName"}]';
         String businessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName"}]';
@@ -109,24 +181,31 @@ private class RulePathSObjectSettingUpsertServiceTest {
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
 
         Test.stopTest();
 
-        Assert.areEqual( 1, rulePathSObjectSettingsEnriched.size(), 'Must return one rulePathSObjectSettingsEnriched' );
-        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSettingsEnriched[0].Name, 'Name field must be: BusinessRulesSetting__c' );
-        Assert.isTrue( String.isBlank( rulePathSObjectSettingsEnriched[0].FieldsToUseInQuery__c ), 'FieldsToUseInQuery__c field must be blank' );
+        Assert.isFalse( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be not empty' );
+        Assert.isTrue( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be empty' );
+
+        Assert.areEqual( 1, result.get( 'RulePathSObjectSetting__c' ).size(), 'Must return one RulePathSObjectSetting__c' );
+
+        Assert.areEqual( rulePathSObjectSettingFakeId, result.get( 'RulePathSObjectSetting__c' )[0].Id, 'Id field must be: ' + rulePathSObjectSettingFakeId );
+        Assert.areEqual( 'BusinessRulesSetting__c', ( (RulePathSObjectSetting__c) result.get( 'RulePathSObjectSetting__c' )[0] ).ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
     }
 
     @isTest 
     private static void dontUpdateBusinessSettingRuleKeyFieldAlreadyInQuery() {
+        String rulePathSObjectSettingFakeId = FixtureFactory.generateFakeId18( RulePathSObjectSetting__c.getSObjectType() );
+        List<String> rulePathFieldSettingFakeIds = FixtureFactory.generateFakeIds18( RulePathFieldSetting__c.getSObjectType(), 2 );
+
+        String rulePathSObjectSettingsPayload = '[{"Id":"'+rulePathSObjectSettingFakeId+'","ObjectAPIName__c":"BusinessRulesSetting__c"}]';
+        String rulePathFieldSettingsPayload = '[{"Id":"'+rulePathFieldSettingFakeIds[0]+'","Name":"Name","ObjectAPIName__c":"BusinessRulesSetting__c"},{"Id":"'+rulePathFieldSettingFakeIds[1]+'","Name":"Object__c","ObjectAPIName__c":"BusinessRulesSetting__c"}]';
+
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( rulePathSObjectSettingsPayload ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( rulePathFieldSettingsPayload ) );
 
         String businessRulesSettingFakeId = FixtureFactory.generateFakeId18( BusinessRulesSetting__c.getSObjectType() );
-
-        String rulepathSObjectSettingsPayload = '[{"Name":"BusinessRulesSetting__c","FieldsToUseInQuery__c":"Name,Object__c"}]';
-
-        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( rulepathSObjectSettingsPayload ) );
 
         String oldBusinessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName"}]';
         String businessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName;Object__c=Account"}]';
@@ -137,23 +216,44 @@ private class RulePathSObjectSettingUpsertServiceTest {
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
 
         Test.stopTest();
 
-        Assert.areEqual( 1, rulePathSObjectSettingsEnriched.size(), 'Must return one rulePathSObjectSettingsEnriched' );
-        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSettingsEnriched[0].Name, 'Name field must be: BusinessRulesSetting__c' );
-        Assert.areEqual( 'Name,Object__c', rulePathSObjectSettingsEnriched[0].FieldsToUseInQuery__c, 'FieldsToUseInQuery__c field must be: Name,Object__c' );
+        Assert.isFalse( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be not empty' );
+        Assert.isFalse( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be not empty' );
+
+        Assert.areEqual( 1, result.get( 'RulePathSObjectSetting__c' ).size(), 'Must return one RulePathSObjectSetting__c' );
+        Assert.areEqual( 2, result.get( 'RulePathFieldSetting__c' ).size(), 'Must return two RulePathFieldSetting__c' );
+
+        Assert.areEqual( rulePathSObjectSettingFakeId, result.get( 'RulePathSObjectSetting__c' )[0].Id, 'Id field must be: ' + rulePathSObjectSettingFakeId );
+        Assert.areEqual( 'BusinessRulesSetting__c', ( (RulePathSObjectSetting__c) result.get( 'RulePathSObjectSetting__c' )[0] ).ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
+    
+        Map<String,RulePathFieldSetting__c> rulePathFieldSettingByName = (Map<String,RulePathFieldSetting__c>) Maps.indexBy(
+            'Name'
+            , result.get( 'RulePathFieldSetting__c' )
+            , Map<String,RulePathFieldSetting__c>.class
+        );
+
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Name' ), 'Should contains Name in RulePathFieldSetting' );
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Object__c' ), 'Should contains Object__c in RulePathFieldSetting' );
+
+        Assert.areEqual( rulePathFieldSettingFakeIds[0], rulePathFieldSettingByName.get( 'Name' ).Id, 'Id field must be: ' + rulePathFieldSettingFakeIds[0] );
+        Assert.areEqual( rulePathFieldSettingFakeIds[1], rulePathFieldSettingByName.get( 'Object__c' ).Id, 'Id field must be: ' + rulePathFieldSettingFakeIds[1] );
     }
 
     @isTest
     private static void updateBusinessSettingRuleKeyFieldNotInQuery() {
+        String rulePathSObjectSettingFakeId = FixtureFactory.generateFakeId18( RulePathSObjectSetting__c.getSObjectType() );
+        String rulePathFieldSettingFakeId = FixtureFactory.generateFakeId18( RulePathFieldSetting__c.getSObjectType() );
+
+        String rulePathSObjectSettingsPayload = '[{"Id":"'+rulePathSObjectSettingFakeId+'","ObjectAPIName__c":"BusinessRulesSetting__c"}]';
+        String rulePathFieldSettingsPayload = '[{"Id":"'+rulePathFieldSettingFakeId+'","Name":"Name","ObjectAPIName__c":"BusinessRulesSetting__c"}]';
+
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( rulePathSObjectSettingsPayload ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( rulePathFieldSettingsPayload ) );
+
         String businessRulesSettingFakeId = FixtureFactory.generateFakeId18( BusinessRulesSetting__c.getSObjectType() );
-
-        String rulepathSObjectSettingsPayload = '[{"Name":"BusinessRulesSetting__c","FieldsToUseInQuery__c":"Name"}]';
-
-        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( rulepathSObjectSettingsPayload ) );
 
         String oldBusinessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName"}]';
         String businessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName;Object__c=Account"}]';
@@ -164,18 +264,36 @@ private class RulePathSObjectSettingUpsertServiceTest {
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
 
         Test.stopTest();
 
-        Assert.areEqual( 1, rulePathSObjectSettingsEnriched.size(), 'Must return one rulePathSObjectSettingsEnriched' );
-        Assert.areEqual( 'BusinessRulesSetting__c', rulePathSObjectSettingsEnriched[0].Name, 'Name field must be: BusinessRulesSetting__c' );
-        Assert.areEqual( 'Name,Object__c', rulePathSObjectSettingsEnriched[0].FieldsToUseInQuery__c, 'FieldsToUseInQuery__c field must be: Name,Object__c' );
+        Assert.isFalse( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be not empty' );
+        Assert.isFalse( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be not empty' );
+
+        Assert.areEqual( 1, result.get( 'RulePathSObjectSetting__c' ).size(), 'Must return one RulePathSObjectSetting__c' );
+        Assert.areEqual( 2, result.get( 'RulePathFieldSetting__c' ).size(), 'Must return two RulePathFieldSetting__c' );
+
+        Assert.areEqual( rulePathSObjectSettingFakeId, result.get( 'RulePathSObjectSetting__c' )[0].Id, 'Id field must be: ' + rulePathSObjectSettingFakeId );
+        Assert.areEqual( 'BusinessRulesSetting__c', ( (RulePathSObjectSetting__c) result.get( 'RulePathSObjectSetting__c' )[0] ).ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
+    
+        Map<String,RulePathFieldSetting__c> rulePathFieldSettingByName = (Map<String,RulePathFieldSetting__c>) Maps.indexBy(
+            'Name'
+            , result.get( 'RulePathFieldSetting__c' )
+            , Map<String,RulePathFieldSetting__c>.class
+        );
+
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Name' ), 'Should contains Name in RulePathFieldSetting' );
+        Assert.isTrue( rulePathFieldSettingByName.containsKey( 'Object__c' ), 'Should contains Object__c in RulePathFieldSetting' );
+
+        Assert.areEqual( rulePathFieldSettingFakeId, rulePathFieldSettingByName.get( 'Name' ).Id, 'Id field must be: ' + rulePathFieldSettingFakeId );
+        Assert.isNull( rulePathFieldSettingByName.get( 'Object__c' ).Id, 'Id field must be null' );
     }
 
     @isTest 
     private static void dontCreateBusinessSettingInvalidField() {
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( '[]' ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( '[]' ) );
 
         String businessRulesSettingFakeId = FixtureFactory.generateFakeId18( BusinessRulesSetting__c.getSObjectType() );
 
@@ -186,12 +304,13 @@ private class RulePathSObjectSettingUpsertServiceTest {
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( businessRulesSettings, null );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, null );
 
         Test.stopTest();
 
-        Assert.areEqual( 0, rulePathSObjectSettingsEnriched.size(), 'Must dont return rulePathSObjectSettingsEnriched' );
+        Assert.isTrue( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be empty' );
+        Assert.isTrue( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be empty' );
+
         Assert.isTrue( businessRulesSettings[0].hasErrors(), 'Should return field error' );
         Assert.areEqual( 1, businessRulesSettings[0].getErrors().size(), 'BusinessRulesSetting__c must contains only one error' );
         Assert.areEqual( Label.BusinessRulesInvalidFields + ' InvalidField', businessRulesSettings[0].getErrors()[0].getMessage(), 'BusinessRulesSetting__c error message must be: ' + Label.BusinessRulesInvalidFields + ' InvalidField' );
@@ -199,12 +318,16 @@ private class RulePathSObjectSettingUpsertServiceTest {
 
     @isTest 
     private static void dontUpdateBusinessSettingInvalidField() {
+        String rulePathSObjectSettingFakeId = FixtureFactory.generateFakeId18( RulePathSObjectSetting__c.getSObjectType() );
+        String rulePathFieldSettingFakeId = FixtureFactory.generateFakeId18( RulePathFieldSetting__c.getSObjectType() );
+
+        String rulePathSObjectSettingsPayload = '[{"Id":"'+rulePathSObjectSettingFakeId+'","ObjectAPIName__c":"BusinessRulesSetting__c"}]';
+        String rulePathFieldSettingsPayload = '[{"Id":"'+rulePathFieldSettingFakeId+'","Name":"Name","ObjectAPIName__c":"BusinessRulesSetting__c"}]';
+
+        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( rulePathSObjectSettingsPayload ) );
+        BR_RulePathFieldSettingRepository.setMock( new BR_RulePathFieldSettingRepositoryMock( rulePathFieldSettingsPayload ) );
 
         String businessRulesSettingFakeId = FixtureFactory.generateFakeId18( BusinessRulesSetting__c.getSObjectType() );
-
-        String rulepathSObjectSettingsPayload = '[{"Name":"BusinessRulesSetting__c","FieldsToUseInQuery__c":"Name"}]';
-
-        RulePathSObjectSettingRepository.setMock( new RulePathSObjectSettingRepositoryMock( rulepathSObjectSettingsPayload ) );
 
         String oldBusinessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName"}]';
         String businessRulesSettingsPayload = '[{"Id":"'+businessRulesSettingFakeId+'","Object__c":"BusinessRulesSetting__c","RuleKey__c":"Name=TestName;InvalidField=InvalidValue"}]';
@@ -215,13 +338,22 @@ private class RulePathSObjectSettingUpsertServiceTest {
         Test.startTest();
 
         RulePathSObjectSettingUpsertService service = new RulePathSObjectSettingUpsertService();
-        List<RulePathSObjectSetting__c> rulePathSObjectSettingsEnriched =
-            service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
+        Map<String,List<SObject>> result = service.byBusinessRulesSettingsRuleKey( businessRulesSettings, new Map<Id, BusinessRulesSetting__c>( oldBusinessRulesSettings ) );
 
         Test.stopTest();
 
-        Assert.areEqual( 1, rulePathSObjectSettingsEnriched.size(), 'Must return one rulePathSObjectSettingsEnriched' );
-        Assert.areEqual( 'Name', rulePathSObjectSettingsEnriched[0].FieldsToUseInQuery__c, 'FieldsToUseInQuery__c field must be: Name' );
+        Assert.isFalse( result.get( 'RulePathSObjectSetting__c' ).isEmpty(), 'RulePathSObjectSetting__c must be not empty' );
+        Assert.isFalse( result.get( 'RulePathFieldSetting__c' ).isEmpty(), 'RulePathFieldSetting__c must be not empty' );
+
+        Assert.areEqual( 1, result.get( 'RulePathSObjectSetting__c' ).size(), 'Must return one RulePathSObjectSetting__c' );
+        Assert.areEqual( 1, result.get( 'RulePathFieldSetting__c' ).size(), 'Must return one RulePathFieldSetting__c' );
+
+        Assert.areEqual( rulePathSObjectSettingFakeId, result.get( 'RulePathSObjectSetting__c' )[0].Id, 'Id field must be: ' + rulePathSObjectSettingFakeId );
+        Assert.areEqual( 'BusinessRulesSetting__c', ( (RulePathSObjectSetting__c) result.get( 'RulePathSObjectSetting__c' )[0] ).ObjectAPIName__c, 'ObjectAPIName__c field must be: BusinessRulesSetting__c' );
+
+        Assert.areEqual( rulePathFieldSettingFakeId, result.get( 'RulePathFieldSetting__c' )[0].Id, 'RulePathFieldSetting__c Id must be: ' + rulePathFieldSettingFakeId );
+        Assert.areEqual( 'Name', ( (RulePathFieldSetting__c) result.get( 'RulePathFieldSetting__c' )[0] ).Name, 'RulePathFieldSetting__c Name must be Name' );
+
         Assert.isTrue( businessRulesSettings[0].hasErrors(), 'Should return field error' );
         Assert.areEqual( 1, businessRulesSettings[0].getErrors().size(), 'BusinessRulesSetting__c must contains only one error' );
         Assert.areEqual( Label.BusinessRulesInvalidFields + ' InvalidField', businessRulesSettings[0].getErrors()[0].getMessage(), 'BusinessRulesSetting__c error message must be: ' + Label.BusinessRulesInvalidFields + ' InvalidField' );

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Creation/RulePathCreatorService.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Creation/RulePathCreatorService.cls
@@ -33,8 +33,8 @@ public with sharing class RulePathCreatorService {
         Map<String,List<Id>> idsBySObjectApiName = IdHelper.buildMapIdsBySObjectApiName( sObjectIds );
 
         Map<String,RulePathSObjectSetting__c> rulePathSObjectSettingBySObjectName = (Map<String,RulePathSObjectSetting__c>) Maps.indexBy(
-            'Name'
-            , this.rulePathSObjectSettingRepositoryInstance.findByNames( idsBySObjectApiName.keySet() )
+            'ObjectAPIName__c'
+            , this.rulePathSObjectSettingRepositoryInstance.findByObjectAPINames( idsBySObjectApiName.keySet() )
             , Map<String,RulePathSObjectSetting__c>.class
         );
 
@@ -56,13 +56,13 @@ public with sharing class RulePathCreatorService {
                 throw new RulePathCreatorServiceException( 'RulePathSObjectSetting__c not found to SObject: ' + sObjectApiName );
             }
 
-            if( String.isBlank( rulePathSObjectSettingBySObjectName.get( sObjectApiName ).FieldsToUseInQuery__c ) ) {
-                throw new RulePathCreatorServiceException( 'RulePathSObjectSetting__c for SObject: ' + sObjectApiName + ' is missing FieldsToUseInQuery__c' );
+            if( rulePathSObjectSettingBySObjectName.get( sObjectApiName ).RulePathFieldsSettings__r.isEmpty() ) {
+                throw new RulePathCreatorServiceException( 'RulePathSObjectSetting__c for SObject: ' + sObjectApiName + ' is missing Field to Query' );
             }
 
             sObjectRecords.addAll(
                 this.sObjectRepository.buildAndFindByIds(
-                    rulePathSObjectSettingBySObjectName.get( sObjectApiName ).FieldsToUseInQuery__c.split( ',' )
+                    new Set<String>( Lists.byField( rulePathSObjectSettingBySObjectName.get( sObjectApiName ).RulePathFieldsSettings__r, 'Name' ) )
                     , sObjectApiName
                     , idsBySObjectApiName.get( sObjectApiName )
                 )

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Creation/Tests/RulePathCreatorServiceTest.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Creation/Tests/RulePathCreatorServiceTest.cls
@@ -15,7 +15,8 @@ public class RulePathCreatorServiceTest {
             , 'BusinessRulesSetting__c'
         ).createRecord();
 
-        Assert.areEqual( 1, [SELECT Id FROM RulePathSObjectSetting__c WHERE Name = 'BusinessRulesSetting__c'].size(), 'Must create one RulePathSObjectSetting__c' );
+        Assert.areEqual( 1, [SELECT Id FROM RulePathSObjectSetting__c WHERE ObjectAPIName__c = 'BusinessRulesSetting__c'].size(), 'Must create one RulePathSObjectSetting__c' );
+        Assert.areEqual( 1, [SELECT Id FROM RulePathFieldSetting__c].size(), 'Must create one RulePathFieldSetting__c' );
 
         BusinessRulesPath__c businessRulesPath = (BusinessRulesPath__c) new BR_BusinessRulesPathFactory.BR_ExampleValidationRule(
             businessRulesSetting.Id
@@ -59,9 +60,10 @@ public class RulePathCreatorServiceTest {
 
         Assert.areEqual(
             2
-            , [SELECT Id FROM RulePathSObjectSetting__c WHERE Name = 'BusinessRulesPath__c' OR Name = 'BusinessRulesSetting__c'].size()
+            , [SELECT Id FROM RulePathSObjectSetting__c WHERE ObjectAPIName__c = 'BusinessRulesPath__c' OR ObjectAPIName__c = 'BusinessRulesSetting__c'].size()
             , 'Must create two RulePathSObjectSetting__c'
         );
+        Assert.areEqual( 2, [SELECT Id FROM RulePathFieldSetting__c].size(), 'Must create two RulePathFieldSetting__c' );
 
         BusinessRulesPath__c pathForFirstSetting = (BusinessRulesPath__c) new BR_BusinessRulesPathFactory.BR_ExampleValidationRule(
             firstBusinessRulesSetting.Id
@@ -122,7 +124,8 @@ public class RulePathCreatorServiceTest {
 
         TriggerHandler.clearBypass( 'BusinessRulesSettingHandler' );
 
-        Assert.areEqual( 0, [SELECT Id FROM RulePathSObjectSetting__c WHERE Name = 'BusinessRulesSetting__c'].size(), 'Must dont create RulePathSObjectSetting__c' );
+        Assert.areEqual( 0, [SELECT Id FROM RulePathSObjectSetting__c WHERE ObjectAPIName__c = 'BusinessRulesSetting__c'].size(), 'Must dont create RulePathSObjectSetting__c' );
+        Assert.areEqual( 0, [SELECT Id FROM RulePathFieldSetting__c].size(), 'Must dont create RulePathFieldSetting__c' );
 
         Test.startTest();
 
@@ -156,6 +159,8 @@ public class RulePathCreatorServiceTest {
             'BusinessRulesSetting__c'
         ).createRecord();
 
+        Assert.areEqual( 0, [SELECT Id FROM RulePathFieldSetting__c].size(), 'Must dont create RulePathFieldSetting__c' );
+
         Test.startTest();
 
         try{
@@ -163,7 +168,7 @@ public class RulePathCreatorServiceTest {
             List<RulePath__c> createdRulePaths = service.bySObjectIdCreate( businessRulesSetting.Id );
             Assert.fail( 'Must throw a exception' );
         }catch( Exception error ) {
-            Assert.isTrue( error.getMessage().contains( 'is missing FieldsToUseInQuery__c' ) );
+            Assert.isTrue( error.getMessage().contains( 'is missing Field to Query' ) );
         }
 
         Test.stopTest();
@@ -180,7 +185,8 @@ public class RulePathCreatorServiceTest {
             , 'BusinessRulesSetting__c'
         ).createRecord();
 
-        Assert.areEqual( 1, [SELECT Id FROM RulePathSObjectSetting__c WHERE Name = 'BusinessRulesSetting__c'].size(), 'Must create one RulePathSObjectSetting__c' );
+        Assert.areEqual( 1, [SELECT Id FROM RulePathSObjectSetting__c WHERE ObjectAPIName__c = 'BusinessRulesSetting__c'].size(), 'Must create one RulePathSObjectSetting__c' );
+        Assert.areEqual( 1, [SELECT Id FROM RulePathFieldSetting__c].size(), 'Must create one RulePathFieldSetting__c' );
 
         Test.startTest();
 

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Builders/BR_RulePathFieldSettingBuilder.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Builders/BR_RulePathFieldSettingBuilder.cls
@@ -1,0 +1,27 @@
+/**
+ * @description: Class responsible to build RulePathFieldSetting__c SObject
+ * @author: Guilherme Zwipp
+ */
+public with sharing class BR_RulePathFieldSettingBuilder {
+
+    private RulePathFieldSetting__c rulePathFieldSetting;
+
+    public BR_RulePathFieldSettingBuilder() {
+        this.rulePathFieldSetting = new RulePathFieldSetting__c();
+    }
+
+    public BR_RulePathFieldSettingBuilder withName( String name ) {
+        this.rulePathFieldSetting.Name = name;
+        return this;
+    }
+
+    public BR_RulePathFieldSettingBuilder withRelatedSObjectAPIName( String objectApiName ) {
+        this.rulePathFieldSetting.RulePathSObjectSetting__r = new RulePathSObjectSetting__c( ObjectAPIName__c = objectApiName );
+        return this;
+    }
+
+    public RulePathFieldSetting__c build() {
+        return this.rulePathFieldSetting;
+    }
+
+}

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Builders/BR_RulePathFieldSettingBuilder.cls-meta.xml
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Builders/BR_RulePathFieldSettingBuilder.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Builders/BR_RulePathSObjectSettingBuilder.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Builders/BR_RulePathSObjectSettingBuilder.cls
@@ -10,13 +10,8 @@ public with sharing class BR_RulePathSObjectSettingBuilder {
         rulePathSObjectSetting = new RulePathSObjectSetting__c();
     }
 
-    public BR_RulePathSObjectSettingBuilder withName( String name ) {
-        this.rulePathSObjectSetting.Name = name;
-        return this;
-    }
-
-    public BR_RulePathSObjectSettingBuilder withFieldsToUseInQuery( String fieldsToUseInQuery ) {
-        this.rulePathSObjectSetting.FieldsToUseInQuery__c = fieldsToUseInQuery;
+    public BR_RulePathSObjectSettingBuilder withObjectAPIName( String objectAPIName ) {
+        this.rulePathSObjectSetting.ObjectAPIName__c = objectAPIName;
         return this;
     }
 

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Factories/BR_RulePathFieldSettingFactory.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Factories/BR_RulePathFieldSettingFactory.cls
@@ -1,0 +1,23 @@
+/**
+ * @description: Factory to create RulePathFieldSetting__c objects in test context
+ * @author: Guilherme Zwipp
+ */
+@isTest
+public with sharing class BR_RulePathFieldSettingFactory {
+    
+    private static RulePathFieldSetting__c buildNew( String name, String rulePathSObjectSettingId ) {
+        return new RulePathFieldSetting__c(
+            Name = name
+            , RulePathSObjectSetting__c = rulePathSObjectSettingId
+        );
+    }
+
+    public class DefaultRT extends SObjectFactory{
+
+        public DefaultRT( String name, String rulePathSObjectSettingId ) {
+            super( buildNew( name, rulePathSObjectSettingId ) );
+        }
+
+    }
+
+}

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Factories/BR_RulePathFieldSettingFactory.cls-meta.xml
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Factories/BR_RulePathFieldSettingFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Factories/RulePathSObjectSettingFactory.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Factories/RulePathSObjectSettingFactory.cls
@@ -5,21 +5,16 @@
 @isTest
 public with sharing class RulePathSObjectSettingFactory {
 
-    private static RulePathSObjectSetting__c buildNew( String name, String fieldsToUseInQuery ) {
+    private static RulePathSObjectSetting__c buildNew( String objectApiName ) {
         return new RulePathSObjectSetting__c(
-            Name = name
-            , FieldsToUseInQuery__c = fieldsToUseInQuery
+            ObjectAPIName__c = objectApiName
         );
     }
 
     public class DefaultRT extends SObjectFactory{
 
-        public DefaultRT( String name ) {
-            super( buildNew( name, '' ) );
-        }
-
-        public DefaultRT( String name, String fieldsToUseInQuery ) {
-            super( buildNew( name, fieldsToUseInQuery ) );
+        public DefaultRT( String objectApiName ) {
+            super( buildNew( objectApiName ) );
         }
 
     }

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/BR_RulePathFieldSettingRepository.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/BR_RulePathFieldSettingRepository.cls
@@ -1,0 +1,34 @@
+/**
+ * @description: Class to provide stored RulePathFieldSetting__c collections
+ * @author: Guilherme Zwipp
+ */
+public virtual class BR_RulePathFieldSettingRepository extends AbstractRepository {
+
+    private static BR_RulePathFieldSettingRepository instance;
+
+    public static BR_RulePathFieldSettingRepository getInstance() {
+        if ( instance == null ) instance = new BR_RulePathFieldSettingRepository();
+        return instance;
+    }
+
+    protected BR_RulePathFieldSettingRepository() {}
+    
+    public virtual List<RulePathFieldSetting__c> findByObjectNames( List<String> objectNames ) {
+        return [
+            SELECT
+                Id
+                , Name
+                , ObjectAPIName__c
+            FROM
+                RulePathFieldSetting__c
+            WHERE
+                ObjectAPIName__c IN :objectNames
+        ];
+    }
+
+    @TestVisible
+    private static void setMock( BR_RulePathFieldSettingRepository mockInstance ) {
+        instance = mockInstance;
+    }
+
+}

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/BR_RulePathFieldSettingRepository.cls-meta.xml
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/BR_RulePathFieldSettingRepository.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/Mocks/BR_RulePathFieldSettingRepositoryMock.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/Mocks/BR_RulePathFieldSettingRepositoryMock.cls
@@ -1,0 +1,23 @@
+/**
+ * @description: Mock for BR_RulePathFieldSettingRepository class
+ * @author: Guilherme Zwipp
+ */
+@isTest
+public with sharing class BR_RulePathFieldSettingRepositoryMock extends BR_RulePathFieldSettingRepository {
+
+    String payload = '';
+
+    public BR_RulePathFieldSettingRepositoryMock( String payload ) {
+        this.payload = payload;
+    }
+
+    public override List<RulePathFieldSetting__c> findByObjectNames( List<String> objectNames ) {
+        return (List<RulePathFieldSetting__c>) JSON.deserialize( this.payload , List<RulePathFieldSetting__c>.class );
+    }
+
+    
+    public override List<SObject> save (List<SObject> aggregates) {
+        return aggregates;
+    }
+
+}

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/Mocks/BR_RulePathFieldSettingRepositoryMock.cls-meta.xml
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/Mocks/BR_RulePathFieldSettingRepositoryMock.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>58.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/Mocks/RulePathSObjectSettingRepositoryMock.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/Mocks/RulePathSObjectSettingRepositoryMock.cls
@@ -11,11 +11,15 @@ public with sharing class RulePathSObjectSettingRepositoryMock extends RulePathS
         this.payload = payload;
     }
 
-    public override RulePathSObjectSetting__c findByName( String name ) {
+    public override RulePathSObjectSetting__c findByObjectAPIName( String name ) {
         return (RulePathSObjectSetting__c) JSON.deserialize( this.payload, RulePathSObjectSetting__c.class );
     }
 
-    public override List<RulePathSObjectSetting__c> findByNames( List<String> names ) {
+    public override List<RulePathSObjectSetting__c> findByObjectAPINames( List<String> names ) {
+        return (List<RulePathSObjectSetting__c>) JSON.deserialize( this.payload, List<RulePathSObjectSetting__c>.class );
+    }
+
+    public override List<RulePathSObjectSetting__c> findByObjectAPINames( Set<String> names ) {
         return (List<RulePathSObjectSetting__c>) JSON.deserialize( this.payload, List<RulePathSObjectSetting__c>.class );
     }
 

--- a/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/RulePathSObjectSettingRepository.cls
+++ b/force-app/main/FrameWork/MadeByMe/BusinessRules/Utils/Repositories/RulePathSObjectSettingRepository.cls
@@ -13,24 +13,30 @@ public virtual class RulePathSObjectSettingRepository extends AbstractRepository
 
     protected RulePathSObjectSettingRepository() {}
 
-    public virtual RulePathSObjectSetting__c findByName( String name ) {
-        List<RulePathSObjectSetting__c> rulePathSObjectSettings = this.findByNames( new Set<String>{name} );
+    public virtual RulePathSObjectSetting__c findByObjectAPIName( String objectApiName ) {
+        List<RulePathSObjectSetting__c> rulePathSObjectSettings = this.findByObjectAPINames( new Set<String>{objectApiName} );
         return rulePathSObjectSettings.isEmpty() ? null : rulePathSObjectSettings[0];
     }
 
-    public virtual List<RulePathSObjectSetting__c> findByNames( List<String> names ) {
-        return this.findByNames( new Set<String>( names ) );
+    public virtual List<RulePathSObjectSetting__c> findByObjectAPINames( List<String> objectApiNames ) {
+        return this.findByObjectAPINames( new Set<String>( objectApiNames ) );
     }
 
-    public virtual List<RulePathSObjectSetting__c> findByNames( Set<String> names ) {
+    public virtual List<RulePathSObjectSetting__c> findByObjectAPINames( Set<String> objectApiNames ) {
         return[
             SELECT
                 Id
-                , Name
-                , FieldsToUseInQuery__c
+                , ObjectAPIName__c
+                , (
+                    SELECT
+                        Name
+                    FROM 
+                        RulePathFieldsSettings__r
+                    WHERE Name != null
+                )
             FROM
                 RulePathSObjectSetting__c
-            WHERE Name IN :names
+            WHERE ObjectAPIName__c IN :objectApiNames
         ];
     }
 

--- a/force-app/main/default/classes/repositories/SObjectRepository.cls
+++ b/force-app/main/default/classes/repositories/SObjectRepository.cls
@@ -19,7 +19,7 @@ public virtual class SObjectRepository extends AbstractRepository {
         return sObjects.isEmpty() ? null : sObjects[0];
     }
 
-    public List<SObject> buildAndFindByIds( List<String> fields, String SObjectName, List<Id> ids ) {
+    public List<SObject> buildAndFindByIds( Set<String> fields, String SObjectName, List<Id> ids ) {
         String query = 'SELECT ' + String.join( fields, ',' ) + ' FROM ' + SObjectName + ' WHERE Id IN :ids';
 
         return Database.query( query );

--- a/force-app/main/default/classes/utils/Maps.cls
+++ b/force-app/main/default/classes/utils/Maps.cls
@@ -40,6 +40,24 @@ public without sharing class Maps {
         return values;
     }
 
+    public static Map<String, SObject> indexByCompositeKey ( List<String> fieldsName, List<SObject> records, String separator, Type mapType ) {
+
+        if ( Lists.isEmpty(records) ) return (Map<String, SObject>) mapType.newInstance();
+
+        Map<String, SObject> values = (Map<String, SObject>) mapType.newInstance();
+
+        for ( SObject record : records ) {
+
+            List<String> valuesToBuildCompositeKey = getFieldsValues( record, fieldsName );
+
+            if( valuesToBuildCompositeKey.isEmpty() ) continue;
+
+            values.put( String.join( valuesToBuildCompositeKey, separator ), record );
+        }
+
+        return values;
+    }
+
     public static Map<String, List<SObject>> groupBy ( String fieldName, List<SObject> records ) {
 
         if ( Lists.isEmpty( records ) ) return new Map<String, List<SObject>>();
@@ -111,6 +129,20 @@ public without sharing class Maps {
     public static SObject getMapValue ( Map<String,SObject> sObjectByKey, String key ) {
         if( sObjectByKey.containsKey( key ) ) return sObjectByKey.get( key );
         return null;
+    }
+
+    private static List<String> getFieldsValues( SObject record, List<String> fields ) {
+
+        List<String> values = new List<String>();
+
+        for ( String field : fields ) {
+            String value = getFieldValue( record, field );
+            if( value == null ) continue;
+
+            values.add( value );
+        }
+
+        return values;
     }
 
     private static String getFieldValue( SObject record, String field ) {


### PR DESCRIPTION
Changed RulePathSObjectSetting__c object relationships to separate objects and fields into different SObjects, enabling easier future changes (e.g., field deletion).